### PR TITLE
Add gamma control

### DIFF
--- a/unstable/wlr-gamma-control-unstable-v1.xml
+++ b/unstable/wlr-gamma-control-unstable-v1.xml
@@ -72,7 +72,7 @@
       tables. At any time the compositor can send a failed event indicating that
       this object is no longer valid.
 
-      There must always be at most one gamma control object per output, which
+      There can only be at most one gamma control object per output, which
       has exclusive access to this particular output. When the gamma control
       object is destroyed, the gamma table is restored to its original value.
     </description>

--- a/unstable/wlr-gamma-control-unstable-v1.xml
+++ b/unstable/wlr-gamma-control-unstable-v1.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_gamma_control_unstable_v1">
+  <copyright>
+    Copyright © 2015 Giulio camuffo
+    Copyright © 2018 Simon Ser
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <description summary="manage gamma tables of outputs">
+    This protocol allows a privileged client to set the gamma tables for
+    outputs.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible changes
+    may be added together with the corresponding interface version bump.
+    Backward incompatible changes are done by bumping the version number in
+    the protocol and interface names and resetting the interface version.
+    Once the protocol is to be declared stable, the 'z' prefix and the
+    version number in the protocol and interface names are removed and the
+    interface version number is reset.
+  </description>
+
+  <interface name="zwlr_gamma_control_manager_v1" version="1">
+    <description summary="manager to create per-output gamma controls">
+      This interface is a manager that allows creating per-output gamma
+      controls.
+    </description>
+
+    <request name="get_gamma_control">
+      <description summary="get a gamma control for an output">
+        Create a gamma control that can be used to adjust gamma tables for the
+        provided output.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_gamma_control_v1"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        All objects created by the manager will still remain valid, until their
+        appropriate destroy request has been called.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_gamma_control_v1" version="1">
+    <description summary="adjust gamma tables for an output">
+      This interface allows a client to adjust gamma tables for a particular
+      output.
+
+      The client will receive the gamma size, and will then be able to set gamma
+      tables. At any time the compositor can send a failed event indicating that
+      this object is no longer valid.
+
+      There must always be at most one gamma control object per output, which
+      has exclusive access to this particular output. When the gamma control
+      object is destroyed, the gamma table is restored to its original value.
+    </description>
+
+    <event name="gamma_size">
+      <description summary="size of gamma ramps">
+        Advertise the size of each gamma ramp.
+
+        This event is sent immediately when the gamma control object is created.
+      </description>
+      <arg name="size" type="uint"/>
+    </event>
+
+    <enum name="error">
+      <entry name="invalid_gamma" value="1" summary="invalid gamma tables"/>
+    </enum>
+
+    <request name="set_gamma">
+      <description summary="set the gamma table">
+        Set the gamma table. The file descriptor can be memory-mapped to provide
+        the raw gamma table, which contains successive gamma ramps for the red,
+        green and blue channels. Each gamma ramp is an array of 16-byte unsigned
+        integers which has the same length as the gamma size.
+
+        The file descriptor data must have the same length as three times the
+        gamma size.
+      </description>
+      <arg name="fd" type="fd" summary="gamma table file descriptor"/>
+    </request>
+
+    <event name="failed">
+      <description summary="object no longer valid">
+        This event indicates that the gamma control is no longer valid. This
+        can happen for a number of reasons, including:
+        - The output doesn't support gamma tables
+        - Setting the gamma tables failed
+        - Another client already has exclusive gamma control for this output
+        - The compositor has transfered gamma control to another client
+
+        Upon receiving this event, the client should destroy this object.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy this control">
+        Destroys the gamma control object. If the object is still valid, this
+        restores the original gamma tables.
+      </description>
+    </request>
+  </interface>
+</protocol>

--- a/unstable/wlr-gamma-control-unstable-v1.xml
+++ b/unstable/wlr-gamma-control-unstable-v1.xml
@@ -83,7 +83,7 @@
 
         This event is sent immediately when the gamma control object is created.
       </description>
-      <arg name="size" type="uint"/>
+      <arg name="size" type="uint" summary="number of elements in a ramp"/>
     </event>
 
     <enum name="error">


### PR DESCRIPTION
This uses file descriptors instead of arrays to fix https://github.com/swaywm/wlroots/issues/1135.

It also adds descriptions and clearer semantics. `reset_gamma` is removed in favour of using the `destroy` request, and a `failed` event is added.

As always, comments are welcome. Do we want anything else in this protocol?