### PR TITLE
Support primary selection in data-control

### DIFF
--- a/unstable/wlr-data-control-unstable-v1.xml
+++ b/unstable/wlr-data-control-unstable-v1.xml
@@ -103,9 +103,6 @@
         event, the new data_offer object will send out
         wlr_data_control_offer.offer events to describe the MIME types it
         offers.
-
-        This event replaces the previous data offer, which should be destroyed
-        by the client.
       </description>
       <arg name="id" type="new_id" interface="zwlr_data_control_offer_v1"/>
     </event>

--- a/unstable/wlr-data-control-unstable-v1.xml
+++ b/unstable/wlr-data-control-unstable-v1.xml
@@ -111,7 +111,7 @@
     </event>
 
     <event name="selection">
-      <description summary="introduce a new wlr_data_control_offer">
+      <description summary="advertise new selection">
         The selection event is sent out to notify the client of a new
         wlr_data_control_offer for the selection for this device. The
         wlr_data_control_device.data_offer and the wlr_data_control_offer.offer

--- a/unstable/wlr-data-control-unstable-v1.xml
+++ b/unstable/wlr-data-control-unstable-v1.xml
@@ -2,6 +2,7 @@
 <protocol name="wlr_data_control_unstable_v1">
   <copyright>
     Copyright © 2018 Simon Ser
+    Copyright © 2019 Ivan Molodetskikh
 
     Permission to use, copy, modify, distribute, and sell this
     software and its documentation for any purpose is hereby granted
@@ -79,8 +80,10 @@
 
     <request name="set_selection">
       <description summary="copy data to the selection">
-        All objects created by the device will still remain valid, until their
-        appropriate destroy request has been called.
+        This request asks the compositor to set the selection to the data from
+        the source on behalf of the client.
+
+        To unset the selection, set the source to NULL.
       </description>
       <arg name="source" type="object" interface="zwlr_data_control_source_v1"
         allow-null="true"/>

--- a/unstable/wlr-data-control-unstable-v1.xml
+++ b/unstable/wlr-data-control-unstable-v1.xml
@@ -83,6 +83,9 @@
         This request asks the compositor to set the selection to the data from
         the source on behalf of the client.
 
+        The given source may not be used in any further set_selection or
+        set_primary_selection requests.
+
         To unset the selection, set the source to NULL.
       </description>
       <arg name="source" type="object" interface="zwlr_data_control_source_v1"
@@ -161,6 +164,9 @@
       <description summary="copy data to the primary selection">
         This request asks the compositor to set the primary selection to the
         data from the source on behalf of the client.
+
+        The given source may not be used in any further set_selection or
+        set_primary_selection requests.
 
         To unset the primary selection, set the source to NULL.
 

--- a/unstable/wlr-data-control-unstable-v1.xml
+++ b/unstable/wlr-data-control-unstable-v1.xml
@@ -84,7 +84,8 @@
         the source on behalf of the client.
 
         The given source may not be used in any further set_selection or
-        set_primary_selection requests.
+        set_primary_selection requests. Attempting to use a previously used
+        source is a protocol error.
 
         To unset the selection, set the source to NULL.
       </description>
@@ -166,7 +167,8 @@
         data from the source on behalf of the client.
 
         The given source may not be used in any further set_selection or
-        set_primary_selection requests.
+        set_primary_selection requests. Attempting to use a previously used
+        source is a protocol error.
 
         To unset the primary selection, set the source to NULL.
 
@@ -176,6 +178,11 @@
       <arg name="source" type="object" interface="zwlr_data_control_source_v1"
         allow-null="true"/>
     </request>
+
+    <enum name="error" since="2">
+      <entry name="used_source" value="1"
+        summary="source given to set_selection or set_primary_selection was already used before"/>
+    </enum>
   </interface>
 
   <interface name="zwlr_data_control_source_v1" version="1">

--- a/unstable/wlr-data-control-unstable-v1.xml
+++ b/unstable/wlr-data-control-unstable-v1.xml
@@ -41,7 +41,7 @@
     interface version number is reset.
   </description>
 
-  <interface name="zwlr_data_control_manager_v1" version="1">
+  <interface name="zwlr_data_control_manager_v1" version="2">
     <description summary="manager to control data devices">
       This interface is a manager that allows creating per-seat data device
       controls.
@@ -71,7 +71,7 @@
     </request>
   </interface>
 
-  <interface name="zwlr_data_control_device_v1" version="1">
+  <interface name="zwlr_data_control_device_v1" version="2">
     <description summary="manage a data device for a seat">
       This interface allows a client to manage a seat's selection.
 
@@ -98,11 +98,13 @@
     <event name="data_offer">
       <description summary="introduce a new wlr_data_control_offer">
         The data_offer event introduces a new wlr_data_control_offer object,
-        which will subsequently be used in the wlr_data_control_device.selection
-        event. Immediately following the wlr_data_control_device.data_offer
-        event, the new data_offer object will send out
-        wlr_data_control_offer.offer events to describe the MIME types it
-        offers.
+        which will subsequently be used in either the
+        wlr_data_control_device.selection event (for the regular clipboard
+        selections) or the wlr_data_control_device.primary_selection event (for
+        the primary clipboard selections). Immediately following the
+        wlr_data_control_device.data_offer event, the new data_offer object
+        will send out wlr_data_control_offer.offer events to describe the MIME
+        types it offers.
       </description>
       <arg name="id" type="new_id" interface="zwlr_data_control_offer_v1"/>
     </event>
@@ -129,6 +131,38 @@
         the client.
       </description>
     </event>
+
+    <!-- Version 2 additions -->
+
+    <event name="primary_selection" since="2">
+      <description summary="advertise new primary selection">
+        The primary_selection event is sent out to notify the client of a new
+        wlr_data_control_offer for the primary selection for this device. The
+        wlr_data_control_device.data_offer and the wlr_data_control_offer.offer
+        events are sent out immediately before this event to introduce the data
+        offer object. The primary_selection event is sent to a client when a
+        new primary selection is set. The wlr_data_control_offer is valid until
+        a new wlr_data_control_offer or NULL is received. The client must
+        destroy the previous primary selection wlr_data_control_offer, if any,
+        upon receiving this event.
+      </description>
+      <arg name="id" type="object" interface="zwlr_data_control_offer_v1"
+        allow-null="true"/>
+    </event>
+
+    <request name="set_primary_selection" since="2">
+      <description summary="copy data to the primary selection">
+        This request asks the compositor to set the primary selection to the
+        data from the source on behalf of the client.
+
+        To unset the primary selection, set the source to NULL.
+
+        The compositor will ignore this request if it does not support primary
+        selection.
+      </description>
+      <arg name="source" type="object" interface="zwlr_data_control_source_v1"
+        allow-null="true"/>
+    </request>
   </interface>
 
   <interface name="zwlr_data_control_source_v1" version="1">

--- a/unstable/wlr-data-control-unstable-v1.xml
+++ b/unstable/wlr-data-control-unstable-v1.xml
@@ -120,6 +120,9 @@
         wlr_data_control_offer or NULL is received. The client must destroy the
         previous selection wlr_data_control_offer, if any, upon receiving this
         event.
+
+        The first selection event is sent upon binding the
+        wlr_data_control_device object.
       </description>
       <arg name="id" type="object" interface="zwlr_data_control_offer_v1"
         allow-null="true"/>
@@ -145,6 +148,10 @@
         a new wlr_data_control_offer or NULL is received. The client must
         destroy the previous primary selection wlr_data_control_offer, if any,
         upon receiving this event.
+
+        If the compositor supports primary selection, the first
+        primary_selection event is sent upon binding the
+        wlr_data_control_device object.
       </description>
       <arg name="id" type="object" interface="zwlr_data_control_offer_v1"
         allow-null="true"/>


### PR DESCRIPTION
These changes add support for the primary selection to the `data-control` protocol, alongside the regular selection. With these changes, clipboard managers (or tools like [wl-clipboard](https://github.com/bugaevc/wl-clipboard)) can work with both regular and primary clipboard contents without refraining to hacks like spawning invisible surfaces and stealing focus. See https://github.com/bugaevc/wl-clipboard/issues/24.

With these changes, invalidation of data offers is no longer "automatic" upon receiving a new data offer or selection, and instead should be controlled by the compositor using the new `wlr_data_control_offer_v1.finished` event. This is to support
- two different data offers (one for the regular clipboard and one for the primary clipboard);
- one data offer shared between the regular and the primary clipboard (think tools like [xcutsel](https://linux.die.net/man/1/xcutsel) for synchronizing regular and primary clipboards: it's possible to simply receive the regular clipboard data offer and set it as the primary selection too without having to copy it).

cc @bugaevc @emersion 