### PR TITLE
WIP: Added wlr-workspace-unstable-v1.xml

### DIFF
--- a/unstable/wlr-workspace-unstable-v1.xml
+++ b/unstable/wlr-workspace-unstable-v1.xml
@@ -30,15 +30,17 @@
       Workspaces, also called virtual desktops, are groups of surfaces. A compositor
       with a concept of workspaces may only show some such groups of surfaces (those of
       'active' workspaces) at a time. Workspaces may contain surfaces from one or more
-      outputs, such that activating the workspace will request that the compositor
-      display the workspace's surfaces on those outputs, whereas the compositor may hide
-      or otherwise de-emphasise surfaces that are associated only with inactive
+      outputs, and 'activating' a workspace is a request that the compositor display
+      those surfaces on those outputs as normal, whereas the compositor may hide or
+      otherwise de-emphasise surfaces that are associated only with 'inactive'
       workspaces. By associating a set of outputs with each workspace, each output may
       have its own unique set of workspaces, or all outputs (or any other arbitrary
-      grouping) may share workspaces. Workspaces may be conceptually arranged in a grid
-      of arbitrary dimension. The purpose of this protocol is to enable the creation of
-      taskbars and docks by providing them with a list of workspaces and their
-      properties, and allowing them to activate and deactivate workspaces.
+      grouping) may share workspaces. Compositors may optionally conceptually arrange
+      workspaces with a common set of outputs in an N-dimensional grid.
+
+      The purpose of this protocol is to enable the creation of taskbars and docks by
+      providing them with a list of workspaces and their properties, and allowing them
+      to activate and deactivate workspaces.
 
       After a client binds the zwlr_workspace_manager_v1, each workspace will be sent
       via the workspace event.
@@ -87,14 +89,14 @@
       activate or deactivate the workspace.
     </description>
 
-    <event name="output">
+    <event name="enter">
       <description summary="output added to workspace">
         This event is emitted whenever an output is added to the workspace.
       </description>
       <arg name="output" type="object" interface="wl_output"/>
     </event>
 
-    <event name="output_remove">
+    <event name="leave">
       <description summary="output removed from workspace">
         This event is emitted whenever an output is removed from the workspace.
       </description>
@@ -106,19 +108,27 @@
         This event is emitted immediately after the zwlr_workspace_handle_v1 is created
         and whenever the name of the workspace changes.
       </description>
-      <arg name="number" type="int"/>
+      <arg name="name" type="string"/>
     </event>
 
     <event name="coordinates">
       <description summary="workspace coordinates changed">
-        If the compositor assigns coordinates to workspaces, this event is emitted
-        immediately after the zwlr_workspace_handle_v1 is created and whenever the
-        coordinates of the workspace change. Coordinates have an arbitrary number of
-        dimensions with an unsigned integer position for each dimension. Among a set of
-        workspaces that have identical sets of outputs, workspaces must have unique
-        coordinates with the same number of dimensions, such that the workspaces form a
-        grid with at most one workspace in each position. By convention, 2D coordinates
-        represent [y_pos, x_pos].
+        This event is used to organize workspaces spatially into an N-dimensional grid,
+        and if supported, is emitted immediately after the zwlr_workspace_handle_v1 is
+        created and whenever the coordinates of the workspace change. Compositors may
+        not send this event if they do not conceptually arrange workspaces in this way.
+
+        Coordinates have an arbitrary number of dimensions with an uint32 position along
+        each dimension. By convention, the first dimension is X, the second Y, the third
+        Z, and so on. The compositor may chose to utilize these events for a more novel
+        workspace layout convention, however. No guarantee is made about the grid being
+        filled or bounded; there may be a workspace at coordinate 1 and another at
+        coordinate 1000 and none in between.
+
+        Among a set of workspaces that have identical sets of outputs, workspaces must
+        have unique coordinates of the same dimensionality. Coordinates otherwise need
+        not be unique: in this way independent grids can exist for each set of outputs
+        that share workspaces.
       </description>
       <arg name="coordinates" type="array"/>
     </event>

--- a/unstable/wlr-workspace-unstable-v1.xml
+++ b/unstable/wlr-workspace-unstable-v1.xml
@@ -117,13 +117,16 @@
         and if supported, is emitted immediately after the zwlr_workspace_handle_v1 is
         created and whenever the coordinates of the workspace change. Compositors may
         not send this event if they do not conceptually arrange workspaces in this way.
+        If compositors simply number workspaces, without any geometric interpretation,
+        they may send 1D coordinates, which clients should not interpret as implying any
+        geometry.
 
         Coordinates have an arbitrary number of dimensions with an uint32 position along
-        each dimension. By convention, the first dimension is X, the second Y, the third
-        Z, and so on. The compositor may chose to utilize these events for a more novel
-        workspace layout convention, however. No guarantee is made about the grid being
-        filled or bounded; there may be a workspace at coordinate 1 and another at
-        coordinate 1000 and none in between.
+        each dimension. By convention if N>1, the first dimension is X, the second Y,
+        the third Z, and so on. The compositor may chose to utilize these events for a
+        more novel workspace layout convention, however. No guarantee is made about the
+        grid being filled or bounded; there may be a workspace at coordinate 1 and
+        another at coordinate 1000 and none in between.
 
         Among a set of workspaces that have identical sets of outputs, workspaces must
         have unique coordinates of the same dimensionality. Coordinates otherwise need
@@ -199,14 +202,14 @@
       </description>
     </request>
 
-    <request name="done">
+    <request name="commit">
       <description summary="all requests about the workspace have been sent">
         The client must send this request after it has finished sending other requests.
-        The compositor must process a series of requests preceding a done request
+        The compositor must process a series of requests preceding a commit request
         atomically. This includes requests on other zwlr_workspace_handle_v1 objects: if
         the client sends requests for multiple zwlr_workspace_handle_v1 objects, the
-        compositor must wait until a done request has been sent for every
-        zwlr_workspace_handle_v1 involved, and process all of the preceding requests
+        compositor must wait until a commit request has been sent for every one of those
+        zwlr_workspace_handle_v1 objects, and process all of the preceding requests
         atomically. This is important so that say, deactivating one workspace and
         activating another can be treated atomically.
 

--- a/unstable/wlr-workspace-unstable-v1.xml
+++ b/unstable/wlr-workspace-unstable-v1.xml
@@ -29,15 +29,16 @@
     <description summary="list and control workspaces">
       Workspaces, also called virtual desktops, are groups of surfaces. A
       compositor with a concept of workspaces may only show some such groups of
-      surfaces (those of 'active' workspaces) at a time. Workspaces may contain
-      surfaces from one or more outputs, and 'activating' a workspace is a
-      request that the compositor display those surfaces on those outputs as
-      normal, whereas the compositor may hide or otherwise de-emphasise surfaces
-      that are associated only with 'inactive' workspaces. By associating a set
-      of outputs with each workspace, each output may have its own unique set of
-      workspaces, or all outputs (or any other arbitrary grouping) may share
-      workspaces. Compositors may optionally conceptually arrange workspaces
-      with a common set of outputs in an N-dimensional grid.
+      surfaces (those of 'active' workspaces) at a time. 'Activating' a
+      workspace is a request for the compositor to display that workspace's
+      surfaces as normal, whereas the compositor may hide or otherwise
+      de-emphasise surfaces that are associated only with 'inactive' workspaces.
+      Workspaces are grouped by which sets of outputs they correspond to, and
+      may contain surfaces only from those outputs. In this way, it is possible
+      for each output to have its own set of workspaces, or for all outputs (or
+      any other arbitrary grouping) to share workspaces. Compositors may
+      optionally conceptually arrange each group of workspaces in an
+      N-dimensional grid.
 
       The purpose of this protocol is to enable the creation of taskbars and
       docks by providing them with a list of workspaces and their properties,
@@ -47,15 +48,15 @@
       sent via the workspace event.
     </description>
 
-    <event name="workspace">
-      <description summary="a workspace has been created">
-        This event is emitted whenever a new workspace has been created.
+    <event name="workspace_group">
+      <description summary="a workspace group has been created">
+        This event is emitted whenever a new workspace group has been created.
 
-        All initial details of the workspace (outputs, name, coordinates) will
-        be sent immediately after this event via the corresponding events in
-        zwlr_workspace_handle_v1.
+        All initial details of the workspace group (workspaces, outputs) will be
+        sent immediately after this event via the corresponding events in
+        zwlr_workspace_group_handle_v1.
       </description>
-      <arg name="workspace" type="new_id" interface="zwlr_workspace_handle_v1"/>
+      <arg name="workspace_group" type="new_id" interface="zwlr_workspace_group_handle_v1"/>
     </event>
 
     <event name="finished">
@@ -70,12 +71,64 @@
     <request name="stop">
       <description summary="stop sending events">
         Indicates the client no longer wishes to receive events for new
-        workspaces. However the compositor may emit further workspace events,
-        until the finished event is emitted.
+        workspace groups. However the compositor may emit further workspace
+        events, until the finished event is emitted.
 
         The client must not send any more requests after this one.
       </description>
     </request>
+  </interface>
+
+  <interface name="zwlr_workspace_group_handle_v1" version="1">
+    <description summary="a workspace group assigned to a set of outputs">
+      A zwlr_workspace_group_handle_v1 object represents a a workspace group
+      that is assigned a set of outputs and contains a number of workspaces.
+
+      The set of outputs assigned to the workspace group is conveyed to the
+      client via enter and leave events, and ita workspaces are conveyed with
+      the workspace event.
+    </description>
+
+    <event name="enter">
+      <description summary="output assigned to workspace group">
+        This event is emitted whenever an output is assigned to the workspace
+        group.
+      </description>
+      <arg name="output" type="object" interface="wl_output"/>
+    </event>
+
+    <event name="leave">
+      <description summary="output removed from workspace group">
+        This event is emitted whenever an output is removed from the workspace
+        group.
+      </description>
+      <arg name="output" type="object" interface="wl_output"/>
+    </event>
+
+    <event name="workspace">
+      <description summary="workspace added to workspace group">
+        This event is emitted whenever a new workspace has been created.
+
+        All initial details of the workspace (name, coordinates, state) will
+        be sent immediately after this event via the corresponding events in
+        zwlr_workspace_handle_v1.
+      </description>
+      <arg name="workspace" type="new_id" interface="zwlr_workspace_handle_v1"/>
+    </event>
+
+    <event name="done">
+      <description summary="all information about the workspace group has been sent">
+        This event is sent after all changes in the workspace group state have
+        been sent.
+
+        This allows changes to one or more zwlr_workspace_group_handle_v1
+        properties to be seen as atomic, even if they happen via multiple
+        events. In particular, an output moving from one workspace group to
+        another sends an enter event and a leave event to the two
+        zwlr_workspace_group_handle_v1 objects in question. The compositor sends
+        both done events only after both other events.
+      </description>
+    </event>
   </interface>
 
   <interface name="zwlr_workspace_handle_v1" version="1">
@@ -84,25 +137,11 @@
       group of surfaces.
 
       Each workspace has a name, conveyed to the client with the name event; a
-      list of states, conveyed to the client with the state event; a list of
-      outputs, conveyed via one or more output events; and optionally a set of
-      coordinates, conveyed to the client with the coordinates event. The client
-      may request that the compositor activate or deactivate the workspace.
+      list of states, conveyed to the client with the state event; and
+      optionally a set of coordinates, conveyed to the client with the
+      coordinates event. The client may request that the compositor activate or
+      deactivate the workspace.
     </description>
-
-    <event name="enter">
-      <description summary="output added to workspace">
-        This event is emitted whenever an output is added to the workspace.
-      </description>
-      <arg name="output" type="object" interface="wl_output"/>
-    </event>
-
-    <event name="leave">
-      <description summary="output removed from workspace">
-        This event is emitted whenever an output is removed from the workspace.
-      </description>
-      <arg name="output" type="object" interface="wl_output"/>
-    </event>
 
     <event name="name">
       <description summary="workspace name changed">
@@ -114,27 +153,23 @@
 
     <event name="coordinates">
       <description summary="workspace coordinates changed">
-        This event is used to organize workspaces spatially into an
-        N-dimensional grid, and if supported, is emitted immediately after the
-        zwlr_workspace_handle_v1 is created and whenever the coordinates of the
-        workspace change. Compositors may not send this event if they do not
+        This event is used to organize workspaces into an N-dimensional grid
+        within a workspace group, and if supported, is emitted immediately after
+        the zwlr_workspace_handle_v1 is created and whenever the coordinates of
+        the workspace change. Compositors may not send this event if they do not
         conceptually arrange workspaces in this way. If compositors simply
         number workspaces, without any geometric interpretation, they may send
         1D coordinates, which clients should not interpret as implying any
         geometry.
 
-        Coordinates have an arbitrary number of dimensions with an uint32
-        position along each dimension. By convention if N>1, the first dimension
-        is X, the second Y, the third Z, and so on. The compositor may chose to
-        utilize these events for a more novel workspace layout convention,
-        however. No guarantee is made about the grid being filled or bounded;
-        there may be a workspace at coordinate 1 and another at coordinate 1000
-        and none in between.
-
-        Among a set of workspaces that have identical sets of outputs,
-        workspaces must have unique coordinates of the same dimensionality.
-        Coordinates otherwise need not be unique: in this way independent grids
-        can exist for each set of outputs that share workspaces.
+        Coordinates have an arbitrary number of dimensions N with an uint32
+        position along each dimension. By convention if N > 1, the first
+        dimension is X, the second Y, the third Z, and so on. The compositor may
+        chose to utilize these events for a more novel workspace layout
+        convention, however. No guarantee is made about the grid being filled or
+        bounded; there may be a workspace at coordinate 1 and another at
+        coordinate 1000 and none in between. Within a workspace group, however,
+        workspaces must have unique coordinates of equal dimensionality.
       </description>
       <arg name="coordinates" type="array"/>
     </event>
@@ -195,8 +230,8 @@
 
         There is no guarantee the workspace will be actually activated, and
         behaviour may be compositor-dependent. For example, activating a
-        workspace may or may not deactivate all other workspaces on the same
-        outputs.
+        workspace may or may not deactivate all other workspaces in the same
+        group.
       </description>
     </request>
 
@@ -217,12 +252,12 @@
         multiple zwlr_workspace_handle_v1 objects, the compositor must wait
         until a commit request has been sent for every one of those
         zwlr_workspace_handle_v1 objects, and process all of the preceding
-        requests atomically. This is important so that say, deactivating one
-        workspace and activating another can be treated atomically.
+        requests atomically. 
 
         This allows changes to the workspace properties to be seen as atomic,
         even if they happen via multiple events, and even if they involve
-        multiple zwlr_workspace_handle_v1 objects.
+        multiple zwlr_workspace_handle_v1 objects, for example, deactivating one
+        workspace and activating another.
       </description>
     </request>
 

--- a/unstable/wlr-workspace-unstable-v1.xml
+++ b/unstable/wlr-workspace-unstable-v1.xml
@@ -198,5 +198,23 @@
         There is no guarantee the workspace will be actually deactivated.
       </description>
     </request>
+
+    <request name="done">
+      <description summary="all requests about the workspace have been sent">
+        The client must send this request after it has finished sending other requests.
+        The compositor must process a series of requests preceding a done request
+        atomically. This includes requests on other zwlr_workspace_handle_v1 objects: if
+        the client sends requests for multiple zwlr_workspace_handle_v1 objects, the
+        compositor must wait until a done request has been sent for every
+        zwlr_workspace_handle_v1 involved, and process all of the preceding requests
+        atomically. This is important so that say, deactivating one workspace and
+        activating another can be treated atomically.
+
+        This allows changes to the workspace properties to be seen as atomic, even if
+        they happen via multiple events, and even if they involve multiple
+        zwlr_workspace_handle_v1 objects.
+      </description>
+    </request>
+
   </interface>
 </protocol>

--- a/unstable/wlr-workspace-unstable-v1.xml
+++ b/unstable/wlr-workspace-unstable-v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <protocol name="wlr_workspace_unstable_v1">
   <copyright>
-    Copyright © 2018 Christopher Billington
+    Copyright © 2019 Christopher Billington
 
     Permission to use, copy, modify, distribute, and sell this
     software and its documentation for any purpose is hereby granted
@@ -27,31 +27,32 @@
 
   <interface name="zwlr_workspace_manager_v1" version="1">
     <description summary="list and control workspaces">
-      Workspaces, also called virtual desktops, are groups of surfaces. A compositor
-      with a concept of workspaces may only show some such groups of surfaces (those of
-      'active' workspaces) at a time. Workspaces may contain surfaces from one or more
-      outputs, and 'activating' a workspace is a request that the compositor display
-      those surfaces on those outputs as normal, whereas the compositor may hide or
-      otherwise de-emphasise surfaces that are associated only with 'inactive'
-      workspaces. By associating a set of outputs with each workspace, each output may
-      have its own unique set of workspaces, or all outputs (or any other arbitrary
-      grouping) may share workspaces. Compositors may optionally conceptually arrange
-      workspaces with a common set of outputs in an N-dimensional grid.
+      Workspaces, also called virtual desktops, are groups of surfaces. A
+      compositor with a concept of workspaces may only show some such groups of
+      surfaces (those of 'active' workspaces) at a time. Workspaces may contain
+      surfaces from one or more outputs, and 'activating' a workspace is a
+      request that the compositor display those surfaces on those outputs as
+      normal, whereas the compositor may hide or otherwise de-emphasise surfaces
+      that are associated only with 'inactive' workspaces. By associating a set
+      of outputs with each workspace, each output may have its own unique set of
+      workspaces, or all outputs (or any other arbitrary grouping) may share
+      workspaces. Compositors may optionally conceptually arrange workspaces
+      with a common set of outputs in an N-dimensional grid.
 
-      The purpose of this protocol is to enable the creation of taskbars and docks by
-      providing them with a list of workspaces and their properties, and allowing them
-      to activate and deactivate workspaces.
+      The purpose of this protocol is to enable the creation of taskbars and
+      docks by providing them with a list of workspaces and their properties,
+      and allowing them to activate and deactivate workspaces.
 
-      After a client binds the zwlr_workspace_manager_v1, each workspace will be sent
-      via the workspace event.
+      After a client binds the zwlr_workspace_manager_v1, each workspace will be
+      sent via the workspace event.
     </description>
 
     <event name="workspace">
       <description summary="a workspace has been created">
         This event is emitted whenever a new workspace has been created.
 
-        All initial details of the workspace (outputs, name, coordinates) will be sent
-        immediately after this event via the corresponding events in
+        All initial details of the workspace (outputs, name, coordinates) will
+        be sent immediately after this event via the corresponding events in
         zwlr_workspace_handle_v1.
       </description>
       <arg name="workspace" type="new_id" interface="zwlr_workspace_handle_v1"/>
@@ -60,17 +61,17 @@
     <event name="finished">
       <description summary="the compositor has finished with the workspace_manager">
         This event indicates that the compositor is done sending events to the
-        zwlr_workspace_manager_v1. The server will destroy the object immediately after
-        sending this request, so it will become invalid and the client should free any
-        resources associated with it.
+        zwlr_workspace_manager_v1. The server will destroy the object
+        immediately after sending this request, so it will become invalid and
+        the client should free any resources associated with it.
       </description> 
     </event> 
 
     <request name="stop">
       <description summary="stop sending events">
-        Indicates the client no longer wishes to receive events for new workspaces.
-        However the compositor may emit further workspace events, until the finished
-        event is emitted.
+        Indicates the client no longer wishes to receive events for new
+        workspaces. However the compositor may emit further workspace events,
+        until the finished event is emitted.
 
         The client must not send any more requests after this one.
       </description>
@@ -79,14 +80,14 @@
 
   <interface name="zwlr_workspace_handle_v1" version="1">
     <description summary="a workspace handing a group of surfaces">
-      A zwlr_workspace_handle_v1 object represents a a workspace that handles a group of
-      surfaces.
+      A zwlr_workspace_handle_v1 object represents a a workspace that handles a
+      group of surfaces.
 
-      Each workspace has a name, conveyed to the client with the name event; a list of
-      states, conveyed to the client with the state event; a list of outputs, conveyed
-      via one or more output events; and optionally a set of coordinates, conveyed to
-      the client with the coordinates event. The client may request that the compositor
-      activate or deactivate the workspace.
+      Each workspace has a name, conveyed to the client with the name event; a
+      list of states, conveyed to the client with the state event; a list of
+      outputs, conveyed via one or more output events; and optionally a set of
+      coordinates, conveyed to the client with the coordinates event. The client
+      may request that the compositor activate or deactivate the workspace.
     </description>
 
     <event name="enter">
@@ -105,42 +106,44 @@
 
     <event name="name">
       <description summary="workspace name changed">
-        This event is emitted immediately after the zwlr_workspace_handle_v1 is created
-        and whenever the name of the workspace changes.
+        This event is emitted immediately after the zwlr_workspace_handle_v1 is
+        created and whenever the name of the workspace changes.
       </description>
       <arg name="name" type="string"/>
     </event>
 
     <event name="coordinates">
       <description summary="workspace coordinates changed">
-        This event is used to organize workspaces spatially into an N-dimensional grid,
-        and if supported, is emitted immediately after the zwlr_workspace_handle_v1 is
-        created and whenever the coordinates of the workspace change. Compositors may
-        not send this event if they do not conceptually arrange workspaces in this way.
-        If compositors simply number workspaces, without any geometric interpretation,
-        they may send 1D coordinates, which clients should not interpret as implying any
+        This event is used to organize workspaces spatially into an
+        N-dimensional grid, and if supported, is emitted immediately after the
+        zwlr_workspace_handle_v1 is created and whenever the coordinates of the
+        workspace change. Compositors may not send this event if they do not
+        conceptually arrange workspaces in this way. If compositors simply
+        number workspaces, without any geometric interpretation, they may send
+        1D coordinates, which clients should not interpret as implying any
         geometry.
 
-        Coordinates have an arbitrary number of dimensions with an uint32 position along
-        each dimension. By convention if N>1, the first dimension is X, the second Y,
-        the third Z, and so on. The compositor may chose to utilize these events for a
-        more novel workspace layout convention, however. No guarantee is made about the
-        grid being filled or bounded; there may be a workspace at coordinate 1 and
-        another at coordinate 1000 and none in between.
+        Coordinates have an arbitrary number of dimensions with an uint32
+        position along each dimension. By convention if N>1, the first dimension
+        is X, the second Y, the third Z, and so on. The compositor may chose to
+        utilize these events for a more novel workspace layout convention,
+        however. No guarantee is made about the grid being filled or bounded;
+        there may be a workspace at coordinate 1 and another at coordinate 1000
+        and none in between.
 
-        Among a set of workspaces that have identical sets of outputs, workspaces must
-        have unique coordinates of the same dimensionality. Coordinates otherwise need
-        not be unique: in this way independent grids can exist for each set of outputs
-        that share workspaces.
+        Among a set of workspaces that have identical sets of outputs,
+        workspaces must have unique coordinates of the same dimensionality.
+        Coordinates otherwise need not be unique: in this way independent grids
+        can exist for each set of outputs that share workspaces.
       </description>
       <arg name="coordinates" type="array"/>
     </event>
 
     <event name="state">
       <description summary="the state of the workspace changed">
-        This event is emitted immediately after the zwlr_workspace_handle_v1 is created
-        and each time the workspace state changes, either because of a compositor action
-        or because of a request in this protocol.
+        This event is emitted immediately after the zwlr_workspace_handle_v1 is
+        created and each time the workspace state changes, either because of a
+        compositor action or because of a request in this protocol.
       </description>
       <arg name="state" type="array"/>
     </event>
@@ -155,22 +158,24 @@
 
     <event name="done">
       <description summary="all information about the workspace has been sent">
-        This event is sent after all changes in the workspace state have been sent.
+        This event is sent after all changes in the workspace state have been
+        sent.
 
-        This allows changes to one or more zwlr_workspace_handle_v1 properties to be
-        seen as atomic, even if they happen via multiple events. In particular, if a
-        workspace changes its coordinates, coordinates events may be sent to multiple
-        zwlr_workspace_handle_v1 objects as workspaces are reordered. The compositor
-        sends the done events only after all coordinates events have been sent.
+        This allows changes to one or more zwlr_workspace_handle_v1 properties
+        to be seen as atomic, even if they happen via multiple events. In
+        particular, if a workspace changes its coordinates, coordinates events
+        may be sent to multiple zwlr_workspace_handle_v1 objects as workspaces
+        are reordered. The compositor sends the done events only after all
+        coordinates events have been sent.
       </description>
     </event>
 
     <event name="remove">
       <description summary="this workspace has been destroyed">
         This event means the zwlr_workspace_handle_v1 has been destroyed. It is
-        guaranteed there won't be any more events for this zwlr_workspace_handle_v1. The
-        zwlr_workspace_handle_v1 becomes inert so any requests will be ignored except
-        the destroy request.
+        guaranteed there won't be any more events for this
+        zwlr_workspace_handle_v1. The zwlr_workspace_handle_v1 becomes inert so
+        any requests will be ignored except the destroy request.
       </description>
     </event>
 
@@ -178,9 +183,9 @@
       <description summary="destroy the zwlr_workspace_handle_v1 object">
         Destroys the zwlr_workspace_handle_v1 object.
 
-        This request should be called either when the client does not want to use the
-        workspace object any more or after the remove event to finalize the destruction
-        of the object.
+        This request should be called either when the client does not want to
+        use the workspace object any more or after the remove event to finalize
+        the destruction of the object.
       </description>
     </request>
 
@@ -188,9 +193,10 @@
       <description summary="activate the workspace">
         Request that this workspace be activated.
 
-        There is no guarantee the workspace will be actually activated, and behaviour
-        may be compositor-dependent. For example, activating a workspace may or may not
-        deactivate all other workspaces on the same outputs.
+        There is no guarantee the workspace will be actually activated, and
+        behaviour may be compositor-dependent. For example, activating a
+        workspace may or may not deactivate all other workspaces on the same
+        outputs.
       </description>
     </request>
 
@@ -204,18 +210,19 @@
 
     <request name="commit">
       <description summary="all requests about the workspace have been sent">
-        The client must send this request after it has finished sending other requests.
-        The compositor must process a series of requests preceding a commit request
-        atomically. This includes requests on other zwlr_workspace_handle_v1 objects: if
-        the client sends requests for multiple zwlr_workspace_handle_v1 objects, the
-        compositor must wait until a commit request has been sent for every one of those
-        zwlr_workspace_handle_v1 objects, and process all of the preceding requests
-        atomically. This is important so that say, deactivating one workspace and
-        activating another can be treated atomically.
+        The client must send this request after it has finished sending other
+        requests. The compositor must process a series of requests preceding a
+        commit request atomically. This includes requests on other
+        zwlr_workspace_handle_v1 objects: if the client sends requests for
+        multiple zwlr_workspace_handle_v1 objects, the compositor must wait
+        until a commit request has been sent for every one of those
+        zwlr_workspace_handle_v1 objects, and process all of the preceding
+        requests atomically. This is important so that say, deactivating one
+        workspace and activating another can be treated atomically.
 
-        This allows changes to the workspace properties to be seen as atomic, even if
-        they happen via multiple events, and even if they involve multiple
-        zwlr_workspace_handle_v1 objects.
+        This allows changes to the workspace properties to be seen as atomic,
+        even if they happen via multiple events, and even if they involve
+        multiple zwlr_workspace_handle_v1 objects.
       </description>
     </request>
 

--- a/unstable/wlr-workspace-unstable-v1.xml
+++ b/unstable/wlr-workspace-unstable-v1.xml
@@ -29,27 +29,29 @@
     <description summary="list and control workspaces">
 
       Workspaces, also called virtual desktops, are groups of surfaces. A compositor
-      with a concept of workspaces may only show one such group of windows (those of the
-      'active' workspace) at a time. Outputs may be grouped together, such that all
-      outputs share workspaces, or a group of outputs (possibly a single output) may
-      have its own set of workspaces, separate from other outputs. The purpose of this
-      protocol is to enable the creation of taskbars and docks by providing them with a
-      list of workspaces for each group of outputs, and allowing them to set the active
-      workspace on each workspace group corresponding to a set of outputs.
+      with a concept of workspaces may only show some such groups of surfaces (those of
+      'active' workspaces) at a time. Workspaces may contain surfaces from one or more
+      outputs, such that activating the workspace will cause the compositor to display
+      the workspace's surfaces on those outputs. In this way, each output may have its
+      own unique set of workspaces, or all outputs (or any other arbitrary grouping) may
+      share workspaces. Workspaces may be conceptually arranged in a grid of arbitrary
+      dimension. The purpose of this protocol is to enable the creation of taskbars and
+      docks by providing them with a list of workspaces and their properties, and
+      allowing them to activate and deactivate workspaces.
 
-      After a client binds the zwlr_workspace_manager_v1, each workspace group
-      will be sent via the output_group event
+      After a client binds the zwlr_workspace_manager_v1, each workspace will be sent
+      via the workspace event.
     </description>
 
-    <event name="workspace_group">
-      <description summary="a workspace group has been created">
-        This event is emitted whenever a new workspace group has been created.
+    <event name="workspace">
+      <description summary="a workspace has been created">
+        This event is emitted whenever a new workspace has been created.
 
-        All initial details of the workspace_group (workspaces, outputs) will be sent
+        All initial details of the workspace (outputs, name, coordinates) will be sent
         immediately after this event via the corresponding events in
-        zwlr_workspace_group_handle_v1.
+        zwlr_workspace_handle_v1.
       </description>
-      <arg name="workspace_group" type="new_id" interface="zwlr_workspace_group_handle_v1"/>
+      <arg name="workspace" type="new_id" interface="zwlr_workspace_handle_v1"/>
     </event>
 
     <event name="finished">
@@ -63,106 +65,61 @@
 
     <request name="stop">
       <description summary="stop sending events">
-        Indicates the client no longer wishes to receive events for new workspace
-        groups. However the compositor may emit further workspace_group events, until
-        the finished event is emitted.
+        Indicates the client no longer wishes to receive events for new workspaces.
+        However the compositor may emit further workspace events, until the finished
+        event is emitted.
 
         The client must not send any more requests after this one.
       </description>
     </request>
   </interface>
 
-  <interface name="zwlr_workspace_group_handle_v1" version="1">
-    <description summary="a set of workspaces for a set of outputs">
-      A zwlr_workspace_group_handle_v1 object represents a set of workspaces shared
-      by a set of outputs. Each output may belong to only one workspace group.
+  <interface name="zwlr_workspace_handle_v1" version="1">
+    <description summary="a workspace handing a group of surfaces">
+      A zwlr_workspace_handle_v1 object represents a a workspace that handles a group of
+      surfaces.
 
-      Each workspace group has a list of outputs, conveyed to the client with the
-      output and output_remove events; and a list of workspaces, conveyed to the client
-      with workspace and workspace_remove events.
+      Each workspace has a name, conveyed to the client with the name event; a list of
+      states, conveyed to the client with the state event; a list of outputs, conveyed
+      via one or more output events; and optionally a set of coordinates, conveyed to
+      the client with the coordinates event. The client may request that the compositor
+      activate or deactivate the workspace.
     </description>
 
     <event name="output">
-      <description summary="output added to group">
-        This event is emitted whenever an output is added to the workspace group.
+      <description summary="output added to workspace">
+        This event is emitted whenever an output is added to the workspace.
       </description>
       <arg name="output" type="object" interface="wl_output"/>
     </event>
 
     <event name="output_remove">
-      <description summary="output removed from group">
-        This event is emitted whenever an output is removed from the workspace group.
+      <description summary="output removed from workspace">
+        This event is emitted whenever an output is removed from the workspace.
       </description>
       <arg name="output" type="object" interface="wl_output"/>
     </event>
 
-    <event name="workspace">
-      <description summary="workspace added to group">
-        This event is emitted whenever a workspace is added to the workspace group.
-
-        All initial details of the workspace (number, state) will be sent immediately
-        after this event via the corresponding events in zwlr_workspace_handle_v1.
-      </description>
-      <arg name="workspace" type="new_id" interface="zwlr_workspace_handle_v1"/>
-    </event>
-
-    <event name="workspace_remove">
-      <description summary="workspace removed from group">
-        This event is emitted whenever a workspace is removed from the workspace group
-      </description>
-      <arg name="workspace" type="object" interface="zwlr_workspace_handle_v1"/>
-    </event>
-
-    <event name="done">
-      <description summary="all information about the workspace group has been sent">
-        This event is sent after all changes in the workspace group state have been
-        sent.
-
-        This allows changes to one or more zwlr_workspace_group_handle_v1 properties to
-        be seen as atomic, even if they happen via multiple events. In particular, an
-        output moving from one workspace group to another sends an output event and an
-        output_remove event to the two zwlr_workspace_group_handle_v1 objects in
-        question. The compositor sends both done events only after both other events.
-      </description>
-    </event>
-
-    <event name="destroyed">
-      <description summary="this workspace group has been destroyed">
-        This event means the zwlr_workspace_group_handle_v1 has been destroyed. It is
-        guaranteed there won't be any more events for this
-        zwlr_workspace_group_handle_v1. The zwlr_workspace_group_handle_v1 becomes inert
-        so any requests will be ignored except the destroy request.
-      </description>
-    </event>
-
-    <request name="destroy" type="destructor">
-      <description summary="destroy the zwlr_workspace_group_handle_v1 object">
-        Destroys the zwlr_workspace_group_handle_v1 object.
-
-        This request should be called either when the client does not want to use the
-        workspace_group anymore or after the closed event to finalize the destruction of
-        the object.
-      </description>
-    </request>
-  </interface>
-
-  <interface name="zwlr_workspace_handle_v1" version="1">
-    <description summary="a workspace belonging to a workspace group">
-      A zwlr_workspace_handle_v1 object represents a a workspace belonging to a
-      workspace group.
-
-      Each workspace group has a number, conveyed to the client with the number event,
-      and a list of states, conveyed to the client with the state event. The client may
-      request the compositor to activate the workspace.
-    </description>
-
-    <event name="number">
-      <description summary="workspace number changed">
+    <event name="name">
+      <description summary="workspace name changed">
         This event is emitted immediately after the zwlr_workspace_handle_v1 is created
-        and whenever the number of the workspace changed. Workspaces within a workspace
-        group are uniquely and contiguously numbered starting from zero.
+        and whenever the name of the workspace changes.
       </description>
       <arg name="number" type="int"/>
+    </event>
+
+    <event name="coordinates">
+      <description summary="workspace coordinates changed">
+        If the compositor assigns coordinates to workspaces, this event is emitted
+        immediately after the zwlr_workspace_handle_v1 is created and whenever the
+        coordinates of the workspace change. Coordinates have an arbitrary number of
+        dimensions with an unsigned integer position for each dimension. Among a set of
+        workspaces that have identical sets of outputs, workspaces must have unique
+        coordinates with the same number of dimensions, such that the workspaces form a
+        grid with at most one workspace in each position. By convention, 2D coordinates
+        represent [y_pos, x_pos].
+      </description>
+      <arg name="coordinates" type="array"/>
     </event>
 
     <event name="state">
@@ -180,7 +137,6 @@
       </description>
 
       <entry name="active" value="0" summary="the workspace is active"/>
-      <entry name="empty" value="1" summary="the workspace contains no toplevels"/>
     </enum>
 
     <event name="done">
@@ -188,14 +144,14 @@
         This event is sent after all changes in the workspace state have been sent.
 
         This allows changes to one or more zwlr_workspace_handle_v1 properties to be
-        seen as atomic, even if they happen via multiple events. In particular, a
-        workspace changing its number sends number events to multiple
-        zwlr_workspace_handle_v1 objects in order to keep their numbers sequential. The
-        compositor sends both done events only after both number events have been sent.
+        seen as atomic, even if they happen via multiple events. In particular, if a
+        workspace changes its coordinates, coordinates events may be sent to multiple
+        zwlr_workspace_handle_v1 objects as workspaces are reordered. The compositor
+        sends the done events only after all coordinates events have been sent.
       </description>
     </event>
 
-    <event name="destroyed">
+    <event name="remove">
       <description summary="this workspace has been destroyed">
         This event means the zwlr_workspace_handle_v1 has been destroyed. It is
         guaranteed there won't be any more events for this zwlr_workspace_handle_v1. The
@@ -205,21 +161,30 @@
     </event>
 
     <request name="destroy" type="destructor">
-      <description summary="destroy the zwlr_workspace_group_handle_v1 object">
+      <description summary="destroy the zwlr_workspace_handle_v1 object">
         Destroys the zwlr_workspace_handle_v1 object.
 
         This request should be called either when the client does not want to use the
-        workspace_group anymore or after the closed event to finalize the destruction of
-        the object.
+        workspace object any more or after the remove event to finalize the destruction
+        of the object.
       </description>
     </request>
 
     <request name="activate">
       <description summary="activate the workspace">
-        Request that this workspace be set as the active workspace for its workspace
-        group.
+        Request that this workspace be activated.
 
-        There is no guarantee the workspace will be actually activated.
+        There is no guarantee the workspace will be actually activated, and behaviour
+        may be compositor-dependent. For example, activating a workspace may or may not
+        deactivate all other workspaces on the same outputs.
+      </description>
+    </request>
+
+    <request name="deactivate">
+      <description summary="activate the workspace">
+        Request that this workspace be deactivated.
+
+        There is no guarantee the workspace will be actually deactivated.
       </description>
     </request>
   </interface>

--- a/unstable/wlr-workspace-unstable-v1.xml
+++ b/unstable/wlr-workspace-unstable-v1.xml
@@ -84,12 +84,12 @@
       A zwlr_workspace_group_handle_v1 object represents a a workspace group
       that is assigned a set of outputs and contains a number of workspaces.
 
-      The set of outputs assigned to the workspace group is conveyed to the
-      client via enter and leave events, and ita workspaces are conveyed with
-      the workspace event.
+      The set of outputs assigned to the workspace group is conveyed to the client via
+      output_enter and output_leave events, and its workspaces are conveyed with
+      workspace events.
     </description>
 
-    <event name="enter">
+    <event name="output_enter">
       <description summary="output assigned to workspace group">
         This event is emitted whenever an output is assigned to the workspace
         group.
@@ -97,7 +97,7 @@
       <arg name="output" type="object" interface="wl_output"/>
     </event>
 
-    <event name="leave">
+    <event name="output_leave">
       <description summary="output removed from workspace group">
         This event is emitted whenever an output is removed from the workspace
         group.
@@ -124,7 +124,7 @@
         This allows changes to one or more zwlr_workspace_group_handle_v1
         properties to be seen as atomic, even if they happen via multiple
         events. In particular, an output moving from one workspace group to
-        another sends an enter event and a leave event to the two
+        another sends an output_enter event and an output_leave event to the two
         zwlr_workspace_group_handle_v1 objects in question. The compositor sends
         both done events only after both other events.
       </description>

--- a/unstable/wlr-workspace-unstable-v1.xml
+++ b/unstable/wlr-workspace-unstable-v1.xml
@@ -27,17 +27,18 @@
 
   <interface name="zwlr_workspace_manager_v1" version="1">
     <description summary="list and control workspaces">
-
       Workspaces, also called virtual desktops, are groups of surfaces. A compositor
       with a concept of workspaces may only show some such groups of surfaces (those of
       'active' workspaces) at a time. Workspaces may contain surfaces from one or more
-      outputs, such that activating the workspace will cause the compositor to display
-      the workspace's surfaces on those outputs. In this way, each output may have its
-      own unique set of workspaces, or all outputs (or any other arbitrary grouping) may
-      share workspaces. Workspaces may be conceptually arranged in a grid of arbitrary
-      dimension. The purpose of this protocol is to enable the creation of taskbars and
-      docks by providing them with a list of workspaces and their properties, and
-      allowing them to activate and deactivate workspaces.
+      outputs, such that activating the workspace will request that the compositor
+      display the workspace's surfaces on those outputs, whereas the compositor may hide
+      or otherwise de-emphasise surfaces that are associated only with inactive
+      workspaces. By associating a set of outputs with each workspace, each output may
+      have its own unique set of workspaces, or all outputs (or any other arbitrary
+      grouping) may share workspaces. Workspaces may be conceptually arranged in a grid
+      of arbitrary dimension. The purpose of this protocol is to enable the creation of
+      taskbars and docks by providing them with a list of workspaces and their
+      properties, and allowing them to activate and deactivate workspaces.
 
       After a client binds the zwlr_workspace_manager_v1, each workspace will be sent
       via the workspace event.

--- a/unstable/wlr-workspace-unstable-v1.xml
+++ b/unstable/wlr-workspace-unstable-v1.xml
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_workspace_unstable_v1">
+  <copyright>
+    Copyright © 2018 Christopher Billington
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <interface name="zwlr_workspace_manager_v1" version="1">
+    <description summary="list and control workspaces">
+
+      Workspaces, also called virtual desktops, are groups of surfaces. A compositor
+      with a concept of workspaces may only show one such group of windows (those of the
+      'active' workspace) at a time. Outputs may be grouped together, such that all
+      outputs share workspaces, or a group of outputs (possibly a single output) may
+      have its own set of workspaces, separate from other outputs. The purpose of this
+      protocol is to enable the creation of taskbars and docks by providing them with a
+      list of workspaces for each group of outputs, and allowing them to set the active
+      workspace on each workspace group corresponding to a set of outputs.
+
+      After a client binds the zwlr_workspace_manager_v1, each workspace group
+      will be sent via the output_group event
+    </description>
+
+    <event name="workspace_group">
+      <description summary="a workspace group has been created">
+        This event is emitted whenever a new workspace group has been created.
+
+        All initial details of the workspace_group (workspaces, outputs) will be sent
+        immediately after this event via the corresponding events in
+        zwlr_workspace_group_handle_v1.
+      </description>
+      <arg name="workspace_group" type="new_id" interface="zwlr_workspace_group_handle_v1"/>
+    </event>
+
+    <event name="finished">
+      <description summary="the compositor has finished with the workspace_manager">
+        This event indicates that the compositor is done sending events to the
+        zwlr_workspace_manager_v1. The server will destroy the object immediately after
+        sending this request, so it will become invalid and the client should free any
+        resources associated with it.
+      </description> 
+    </event> 
+
+    <request name="stop">
+      <description summary="stop sending events">
+        Indicates the client no longer wishes to receive events for new workspace
+        groups. However the compositor may emit further workspace_group events, until
+        the finished event is emitted.
+
+        The client must not send any more requests after this one.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_workspace_group_handle_v1" version="1">
+    <description summary="a set of workspaces for a set of outputs">
+      A zwlr_workspace_group_handle_v1 object represents a set of workspaces shared
+      by a set of outputs. Each output may belong to only one workspace group.
+
+      Each workspace group has a list of outputs, conveyed to the client with the
+      output and output_remove events; and a list of workspaces, conveyed to the client
+      with workspace and workspace_remove events.
+    </description>
+
+    <event name="output">
+      <description summary="output added to group">
+        This event is emitted whenever an output is added to the workspace group.
+      </description>
+      <arg name="output" type="object" interface="wl_output"/>
+    </event>
+
+    <event name="output_remove">
+      <description summary="output removed from group">
+        This event is emitted whenever an output is removed from the workspace group.
+      </description>
+      <arg name="output" type="object" interface="wl_output"/>
+    </event>
+
+    <event name="workspace">
+      <description summary="workspace added to group">
+        This event is emitted whenever a workspace is added to the workspace group.
+
+        All initial details of the workspace (number, state) will be sent immediately
+        after this event via the corresponding events in zwlr_workspace_handle_v1.
+      </description>
+      <arg name="workspace" type="new_id" interface="zwlr_workspace_handle_v1"/>
+    </event>
+
+    <event name="workspace_remove">
+      <description summary="workspace removed from group">
+        This event is emitted whenever a workspace is removed from the workspace group
+      </description>
+      <arg name="workspace" type="object" interface="zwlr_workspace_handle_v1"/>
+    </event>
+
+    <event name="done">
+      <description summary="all information about the workspace group has been sent">
+        This event is sent after all changes in the workspace group state have been
+        sent.
+
+        This allows changes to one or more zwlr_workspace_group_handle_v1 properties to
+        be seen as atomic, even if they happen via multiple events. In particular, an
+        output moving from one workspace group to another sends an output event and an
+        output_remove event to the two zwlr_workspace_group_handle_v1 objects in
+        question. The compositor sends both done events only after both other events.
+      </description>
+    </event>
+
+    <event name="destroyed">
+      <description summary="this workspace group has been destroyed">
+        This event means the zwlr_workspace_group_handle_v1 has been destroyed. It is
+        guaranteed there won't be any more events for this
+        zwlr_workspace_group_handle_v1. The zwlr_workspace_group_handle_v1 becomes inert
+        so any requests will be ignored except the destroy request.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the zwlr_workspace_group_handle_v1 object">
+        Destroys the zwlr_workspace_group_handle_v1 object.
+
+        This request should be called either when the client does not want to use the
+        workspace_group anymore or after the closed event to finalize the destruction of
+        the object.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_workspace_handle_v1" version="1">
+    <description summary="a workspace belonging to a workspace group">
+      A zwlr_workspace_handle_v1 object represents a a workspace belonging to a
+      workspace group.
+
+      Each workspace group has a number, conveyed to the client with the number event,
+      and a list of states, conveyed to the client with the state event. The client may
+      request the compositor to activate the workspace.
+    </description>
+
+    <event name="number">
+      <description summary="workspace number changed">
+        This event is emitted immediately after the zwlr_workspace_handle_v1 is created
+        and whenever the number of the workspace changed. Workspaces within a workspace
+        group are uniquely and contiguously numbered starting from zero.
+      </description>
+      <arg name="number" type="int"/>
+    </event>
+
+    <event name="state">
+      <description summary="the state of the workspace changed">
+        This event is emitted immediately after the zwlr_workspace_handle_v1 is created
+        and each time the workspace state changes, either because of a compositor action
+        or because of a request in this protocol.
+      </description>
+      <arg name="state" type="array"/>
+    </event>
+
+    <enum name="state">
+      <description summary="types of states on the workspace">
+        The different states that a workspace can have.
+      </description>
+
+      <entry name="active" value="0" summary="the workspace is active"/>
+      <entry name="empty" value="1" summary="the workspace contains no toplevels"/>
+    </enum>
+
+    <event name="done">
+      <description summary="all information about the workspace has been sent">
+        This event is sent after all changes in the workspace state have been sent.
+
+        This allows changes to one or more zwlr_workspace_handle_v1 properties to be
+        seen as atomic, even if they happen via multiple events. In particular, a
+        workspace changing its number sends number events to multiple
+        zwlr_workspace_handle_v1 objects in order to keep their numbers sequential. The
+        compositor sends both done events only after both number events have been sent.
+      </description>
+    </event>
+
+    <event name="destroyed">
+      <description summary="this workspace has been destroyed">
+        This event means the zwlr_workspace_handle_v1 has been destroyed. It is
+        guaranteed there won't be any more events for this zwlr_workspace_handle_v1. The
+        zwlr_workspace_handle_v1 becomes inert so any requests will be ignored except
+        the destroy request.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the zwlr_workspace_group_handle_v1 object">
+        Destroys the zwlr_workspace_handle_v1 object.
+
+        This request should be called either when the client does not want to use the
+        workspace_group anymore or after the closed event to finalize the destruction of
+        the object.
+      </description>
+    </request>
+
+    <request name="activate">
+      <description summary="activate the workspace">
+        Request that this workspace be set as the active workspace for its workspace
+        group.
+
+        There is no guarantee the workspace will be actually activated.
+      </description>
+    </request>
+  </interface>
+</protocol>


### PR DESCRIPTION
This is a draft for addressing issue #10.

I likely don't have the C chops to contribute much to wlroots' code (though I might try), but maybe I can talk about protocols.

To accommodate both compositors that have workspaces spanning all outputs, as well as those that have each output with its own independent set of workspaces, this protocol has the concept of 'workspace groups'. A workspace group is a set of outputs that share workspaces. Each output may belong to at most one group. Each workspace group has one active workspace at any one time.  This allows arbitrary grouping of outputs, including the two common cases of all outputs sharing a group and of each output being its own group.

There is more to think about here.

Is the protocol sufficient for required atomicity? If an output moves to a different workspace group, then the 'each output may belong to at most one group' requirement will be violated from the perspective of the client until both an `output` and an `output_remove` event are processed on the two `zwlr_workspace_group_handle_v1` objects. But the compositor can refrain from sending `done` events until both of these events are sent, so we could say that if the client gets an `output` or `output_remove` event, it must wait for the `done` event before it has a consistent state for what groups all the outputs belong to.

Similarly with `zwlr_workspace_handle_v1`, if a workspace changes what its number is, the client must wait for the `done` event in order to see that the 'workspaces are sequentially numbered from zero' requirement is satisfied.

I am also a bit confused about destroy events and requests. If you request to destroy an object, you're just asking to clean up resources - you're not asking the compositor to remove a workspace or whatnot. However, if the compositor *does* remove a workspace (not just move it to a different workspace group), does it send a `destroyed` event?

I suspect the general ideas in this protocol are pretty unobjectionable, but potentially more contentious things that I haven't included are:

Workspaces are simply numbered here. Should it be left that way, or should they be defined on a 2D grid? If we do not allow for information about a 2D grid, then if the compositor is laying out the workspaces this way, panels will not be able to reflect that in how they display workspaces, and they will not be able to implement 'move to workspace left' and 'move to workspace up' functionality, etc.

Should workspaces and/or workspace groups have names?

Here are some events/requests I have not included

zwlr_workspace_manager_v1:
* request: create workspace group

zwlr_workspace_group_v1:
* request: add an output to the group
* request: remove an output from the group
* request: add a workspace to the group
* request: remove a workspace from the group
* request: set a name as a string
* event: name as a string

zwl_workspace_v1:
* event: name as a string
* request: move (change the number of the workspace - processed as an insert to keep numbers sequential)
* request: set name as a string

There is also some question of whether only one workspace can be active at a time. In compositor workspace overview interfaces, you can often see multiple workspaces. However, that's not inconsistent with only one of them being 'active', active doesn't have to mean visible, so I'm not sure if that's a problem.