### PR TITLE
layer-shell: Fix conflict with C++

### DIFF
--- a/unstable/wlr-layer-shell-unstable-v1.xml
+++ b/unstable/wlr-layer-shell-unstable-v1.xml
@@ -58,7 +58,7 @@
       <arg name="surface" type="object" interface="wl_surface"/>
       <arg name="output" type="object" interface="wl_output" allow-null="true"/>
       <arg name="layer" type="uint" enum="layer" summary="layer to add this surface to"/>
-      <arg name="namespace" type="string" summary="namespace for the layer surface"/>
+      <arg name="namespace_" type="string" summary="namespace for the layer surface"/>
     </request>
 
     <enum name="error">


### PR DESCRIPTION
namespace is a C++ keyword and this makes this protocol incompatible,
rename the argument in a way that doesn't conflict.