### PR TITLE
Properly reference zwlr_layer_shell_v1.layer

### DIFF
--- a/unstable/wlr-layer-shell-unstable-v1.xml
+++ b/unstable/wlr-layer-shell-unstable-v1.xml
@@ -295,7 +295,7 @@
 
         Layer is double-buffered, see wl_surface.commit.
       </description>
-      <arg name="layer" type="uint" enum="layer" summary="layer to move this surface to"/>
+      <arg name="layer" type="uint" enum="zwlr_layer_shell_v1.layer" summary="layer to move this surface to"/>
     </request>
   </interface>
 </protocol>


### PR DESCRIPTION
Referencing enums from other interfaces without interface name seems to be invalid.