### PR TITLE
Add a sync_fence event to the export-dmabuf protocol.

### DIFF
--- a/unstable/wlr-export-dmabuf-unstable-v1.xml
+++ b/unstable/wlr-export-dmabuf-unstable-v1.xml
@@ -36,7 +36,7 @@
     interface version number is reset.
   </description>
 
-  <interface name="zwlr_export_dmabuf_manager_v1" version="1">
+  <interface name="zwlr_export_dmabuf_manager_v1" version="2">
     <description summary="manager to inform clients and begin capturing">
       This object is a manager with which to start capturing from sources.
     </description>
@@ -59,7 +59,7 @@
     </request>
   </interface>
 
-  <interface name="zwlr_export_dmabuf_frame_v1" version="1">
+  <interface name="zwlr_export_dmabuf_frame_v1" version="2">
     <description summary="a DMA-BUF frame">
       This object represents a single DMA-BUF frame.
 
@@ -75,6 +75,9 @@
       responsible for closing the associated file descriptor.
 
       All frames are read-only and may not be written into or altered.
+
+      If a sync_fence event is received, clients must wait on the sync
+      fence to be signalled by the compositor before using the frame.
     </description>
 
     <enum name="flags">
@@ -141,9 +144,11 @@
 
     <event name="ready">
       <description summary="indicates frame is available for reading">
-        This event is sent as soon as the frame is presented, indicating it is
-        available for reading. This event includes the time at which
-        presentation happened at.
+        This event is sent as soon as all the data pertaining to the frame has
+        been received by the client. This event includes the time at which
+        the scanout began.
+        If a sync_fence object has been received, the clients must wait for it
+        to be signalled, otherwise the frame can be considered ready to be read.
 
         The timestamp is expressed as tv_sec_hi, tv_sec_lo, tv_nsec triples,
         each component being an unsigned 32-bit value. Whole seconds are in
@@ -199,5 +204,17 @@
         to close any FDs it has been given.
       </description>
     </request>
+
+    <!-- Version 2 additions -->
+
+    <event name="sync_fence" since="2">
+      <description summary="explicit synchronization fence">
+        This event provides a dma_fence kernel object which will be signalled
+        when the client can start sampling from the buffer.
+      </description>
+      <arg name="fd" type="fd"
+           summary="fence fd for last operation on buffer"/>
+    </event>
+
   </interface>
 </protocol>


### PR DESCRIPTION
This commit adds a sync_fence FD to the export-dmabuf protocol, allowing
for clients to synchronize their readout of the frame with the last
operation the compositor performs to the frame, thus eliminating any
race conditions where the compositor gives the frame to a client while
still compositing to it.