### PR TITLE
screencopy: clarify the buffer event description

### DIFF
--- a/unstable/wlr-screencopy-unstable-v1.xml
+++ b/unstable/wlr-screencopy-unstable-v1.xml
@@ -96,12 +96,13 @@
     </description>
 
     <event name="buffer">
-      <description summary="buffer information">
-        Provides information about the frame's buffer. This event is sent once
-        as soon as the frame is created.
+      <description summary="wl_shm buffer information">
+        Provides information about wl_shm buffer parameters that need to be
+        used for this frame. This event is sent once as soon as the frame is
+        created.
 
-        The client should then create a buffer with the provided attributes, and
-        send a "copy" request.
+        The client should then create a buffer with the provided attributes via
+        wl_shm_pool.create_buffer, and send a "copy" request.
       </description>
       <arg name="format" type="uint" enum="wl_shm.format" summary="buffer format"/>
       <arg name="width" type="uint" summary="buffer width"/>


### PR DESCRIPTION
The buffer event provides information specific to wl_shm buffers only.
Without these clarifications, a client can only guess the supported
buffer types and may receive a protocol error when its guess is wrong.

cc @any1