### PR TITLE
layer-shell: output property changes precede configure events

### DIFF
--- a/unstable/wlr-layer-shell-unstable-v1.xml
+++ b/unstable/wlr-layer-shell-unstable-v1.xml
@@ -346,6 +346,12 @@
 
         If the width or height arguments are zero, it means the client should
         decide its own window dimension.
+
+        If this event is associated with a change to the properties of the
+        output, then it will be sent after the events announcing the property
+        changes have been sent. For example, if an output changes size, then
+        xdg_output.logical_size, ..., xdg_output.done would be sent before
+        zwlr_layer_surface_v1.configure .
       </description>
       <arg name="serial" type="uint"/>
       <arg name="width" type="uint"/>


### PR DESCRIPTION
See commit message for justification. One place where the new guarantee would be helpful is 
in being able to safely remove a few lines of swaybg ([main.c#L196-198](https://github.com/swaywm/swaybg/blob/1.0/main.c#L196-L198)), in which the program redraws itself on receiving an output scale change. In practice, this redrawing is not necessary, because the associated configure event always comes afterwards; but this is not guaranteed by the existing spec.

The new text matches the current behavior of kwin and sway when changing output scales. 




