### PR TITLE
screencopy: add support for separate cursor capturing

### DIFF
--- a/unstable/wlr-screencopy-unstable-v1.xml
+++ b/unstable/wlr-screencopy-unstable-v1.xml
@@ -38,7 +38,7 @@
     interface version number is reset.
   </description>
 
-  <interface name="zwlr_screencopy_manager_v1" version="3">
+  <interface name="zwlr_screencopy_manager_v1" version="4">
     <description summary="manager to inform clients and begin capturing">
       This object is a manager which offers requests to start capturing from a
       source.
@@ -47,6 +47,9 @@
     <request name="capture_output">
       <description summary="capture an output">
         Capture the next frame of an entire output.
+
+        When overlay_cursor is 0, software cursors will still be visible on
+        the frame.
       </description>
       <arg name="frame" type="new_id" interface="zwlr_screencopy_frame_v1"/>
       <arg name="overlay_cursor" type="int"
@@ -78,9 +81,29 @@
         appropriate destroy request has been called.
       </description>
     </request>
+
+    <!-- Version 4 additions -->
+    <request name="capture_cursor" since="3">
+      <description summary="capture the hardware cursor">
+        Capture the current hardware cursor used by the compositor, if any.
+      </description>
+      <arg name="cursor" type="new_id" interface="zwlr_screencopy_frame_v1"/>
+      <arg name="seat" type="object" interface="wl_seat"/>
+    </request>
+
+    <request name="pointer_position" since="3">
+      <description summary="report the cursor position">
+        Creates an object that reports the current pointer position on the
+        given wl_output for the given wl_seat.
+      </description>
+      <arg name="reporter" type="new_id"
+        interface="zwlr_screencopy_pointer_reporter_v1"/>
+      <arg name="seat" type="object" interface="wl_seat"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
   </interface>
 
-  <interface name="zwlr_screencopy_frame_v1" version="3">
+  <interface name="zwlr_screencopy_frame_v1" version="4">
     <description summary="a frame ready for copy">
       This object represents a single frame.
 
@@ -185,6 +208,9 @@
     <request name="copy_with_damage" since="2">
       <description summary="copy the frame when it's damaged">
         Same as copy, except it waits until there is damage to copy.
+
+        It is a protocol error to send this request on a zwlr_screencopy_frame_v1
+        that is created by zwlr_screencopy_manager_v1.capture_cursor.
       </description>
       <arg name="buffer" type="object" interface="wl_buffer"/>
     </request>
@@ -228,5 +254,57 @@
         types, and send a "copy" request.
       </description>
     </event>
+
+    <!-- Version 4 additions -->
+    <event name="hotspot" since="4">
+      <description summary="cursor hotspot information">
+        Provides information about cursor hotspot. This event is sent once after
+        the frame is created if the frame is created by
+        zwlr_screencopy_manager_v1.capture_cursor.
+      </description>
+      <arg name="x" type="uint" summary="cursor hotspot x coordinate"/>
+      <arg name="y" type="uint" summary="cursor hotspot y coordinate"/>
+    </event>
+  </interface>
+
+  <interface name="zwlr_screencopy_pointer_reporter_v1" version="1">
+    <description summary="reports pointer information for a seat">
+      This object reports pointer information for a given wl_seat on the given
+      wl_output until destroyed.
+
+      Information reported include the pointer position and cursor image.
+    </description>
+
+    <event name="position">
+      <description summary="reports current pointer position">
+        This event is sent every time the pointer on the wl_seat is moved,
+        reporting its current position in output logical coordinates, see
+        xdg_output.logical_size.
+
+        If the pointer is not on the given wl_output, this event is not sent.
+      </description>
+      <arg name="x" type="uint" summary="pointer position x coordinate"/>
+      <arg name="y" type="uint" summary="pointer position y coordinate"/>
+    </event>
+
+    <event name="cursor">
+      <description summary="reports a cursor image change">
+        This event is sent immediately after the pointer reporter is created,
+        every time a client calls wl_pointer.set_cursor, and every time the
+        pointer is moved on and off the given wl_output.
+
+        If the cursor is rendered as a hardware cursor and is visible on the
+        given wl_output, visible is set to 1 and the image may be obtained by
+        calling zwlr_screencopy_manager_v1.capture_cursor. Otherwise, it is
+        set to 0.
+      </description>
+      <arg name="visible" type="uint" summary="whether the cursor is visible"/>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object">
+        Destroys this cursor reporter.
+      </description>
+    </request>
   </interface>
 </protocol>


### PR DESCRIPTION
This is a proposal for the version 4 of the screencopy protocol, which will support separate cursor capturing. The intended use case would be for custom composition of the cursor after capture, which is suitable for applications like [wayvnc][0] or [Looking Glass][1], and also implementing the [metadata cursor mode for xdg-desktop-portal-wlr][2].

Judging by [existing discussions][3], the ideal place to add this feature would be to the screencopy protocol, which is exactly what is done here.

Issues regarding software cursors has been brought up [here][4]. I think there is no real nice solution to capture software cursors separately, nor does it make sense to try. An application could always draw what looks like a cursor on the screen, which could also be nowhere near the actual pointer location. Therefore, specifying 0 for `overlay_cursor` cannot guarantee no visible cursor appears in the captured image.

Instead, I think the solution is to capture only hardware cursors separately, and if that is not possible, then we simply report that the cursor is invisible and have it be composed onto the screen. This works for all custom composition use cases. This approach is also taken by other capturing APIs, such as DXGI Desktop Duplication on Windows.

Implementation-wise, this should be fairly simple. The existing `capture_output` and `capture_output_region` can remain unchanged. `capture_cursor` can be implemented by reading the hardware cursor, and `zwlr_screencopy_pointer_reporter_v1` can be implemented by a few calls in `wlr_seat_pointer.c`.

/cc @emersion @any1 @Xyene
  
  [0]: https://github.com/any1/wayvnc
  [1]: https://github.com/gnif/LookingGlass
  [2]: https://github.com/emersion/xdg-desktop-portal-wlr/issues/133
  [3]: https://github.com/swaywm/wlroots/pull/2329#issuecomment-753457805
  [4]: https://github.com/emersion/xdg-desktop-portal-wlr/issues/160
